### PR TITLE
Speedup PKCS signing using nil as rand io.Reader

### DIFF
--- a/aws/cloudfront/canned_policy.go
+++ b/aws/cloudfront/canned_policy.go
@@ -2,7 +2,6 @@ package cloudfront
 
 import (
 	"crypto"
-	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
 	"io"
@@ -42,7 +41,7 @@ func (p CannedPolicy) signWithPrivateKey(privateKey *rsa.PrivateKey) ([]byte, er
 	digest := h.Sum(nil)
 
 	// calculates the signature of digest using RSASSA-PKCS1-V1_5-SIGN from RSA PKCS#1 v1.5.
-	if signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, hashFunc, digest); err != nil {
+	if signature, err := rsa.SignPKCS1v15(nil, privateKey, hashFunc, digest); err != nil {
 		return []byte{}, err
 	} else {
 		return signature, nil

--- a/aws/cloudfront/custom_policy.go
+++ b/aws/cloudfront/custom_policy.go
@@ -3,7 +3,6 @@ package cloudfront
 import (
 	"bytes"
 	"crypto"
-	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
 	"io"
@@ -96,7 +95,7 @@ func (p CustomPolicy) signWithPrivateKey(privateKey *rsa.PrivateKey) ([]byte, er
 	digest := h.Sum(nil)
 
 	// calculates the signature of digest using RSASSA-PKCS1-V1_5-SIGN from RSA PKCS#1 v1.5.
-	if signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, hashFunc, digest); err != nil {
+	if signature, err := rsa.SignPKCS1v15(nil, privateKey, hashFunc, digest); err != nil {
 		return []byte{}, err
 	} else {
 		return signature, nil

--- a/aws/cloudfront/signature_test.go
+++ b/aws/cloudfront/signature_test.go
@@ -83,3 +83,21 @@ func TestSignCustomPolicy(t *testing.T) {
 		t.Fatalf("signed policy does not match\n--- Got ---\n%v\n--- Expected ---\n%v\n", signature, expectedCustomSignature)
 	}
 }
+
+func BenchmarkSignCustomPolicy(b *testing.B) {
+	pk, err := NewRSAPrivateKeyFromBytes([]byte(privateKey))
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+
+	pk.Precompute()
+
+	for i := 0; i < b.N; i++ {
+		customPolicy := NewCustomPolicy(testURL, testExpiryTime).AddStartTime(testStartTime).AddSourceIP(testSourceIP)
+		_, err := SignPolicy(pk, customPolicy, "APKA9ONS7QCOWEXAMPLE")
+
+		if err != nil {
+			b.Fatalf("%v", err)
+		}
+	}
+}


### PR DESCRIPTION
With rand.Reader

```
PASS
BenchmarkSignCustomPolicy            100          10536927 ns/op
ok      /sc-gaws/aws/cloudfront    1.930s
```

With nil instead of rand.Reader

```
PASS
BenchmarkSignCustomPolicy            200           7775237 ns/op
ok     /sc-gaws/aws/cloudfront    3.284s
```
