### PR TITLE
Use openssl instead of crypto

### DIFF
--- a/aws/cloudfront/canned_policy.go
+++ b/aws/cloudfront/canned_policy.go
@@ -1,12 +1,11 @@
 package cloudfront
 
 import (
-	"crypto"
-	"crypto/rsa"
 	"fmt"
-	"io"
 	"strings"
 	"time"
+
+	"github.com/carlosmn/openssl"
 )
 
 const (
@@ -33,18 +32,7 @@ func (p CannedPolicy) String() string {
 }
 
 // signWithPrivateKey returns a binary encoding of the Canned Policy signature
-func (p CannedPolicy) signWithPrivateKey(privateKey *rsa.PrivateKey) ([]byte, error) {
-	// create a sha1 digest of our policy
-	hashFunc := crypto.SHA1
-	h := hashFunc.New()
-	io.WriteString(h, p.String())
-	digest := h.Sum(nil)
-
+func (p CannedPolicy) signWithPrivateKey(privateKey openssl.PrivateKey) ([]byte, error) {
 	// calculates the signature of digest using RSASSA-PKCS1-V1_5-SIGN from RSA PKCS#1 v1.5.
-	// NOTE: By passing in nil instead of rand.Reader here, we disable RSA blinding.
-	if signature, err := rsa.SignPKCS1v15(nil, privateKey, hashFunc, digest); err != nil {
-		return []byte{}, err
-	} else {
-		return signature, nil
-	}
+	return privateKey.SignPKCS1v15(openssl.SHA1_Method, []byte(p.String()))
 }

--- a/aws/cloudfront/custom_policy.go
+++ b/aws/cloudfront/custom_policy.go
@@ -2,12 +2,11 @@ package cloudfront
 
 import (
 	"bytes"
-	"crypto"
-	"crypto/rsa"
 	"encoding/json"
-	"io"
 	"strings"
 	"time"
+
+	"github.com/carlosmn/openssl"
 )
 
 // CustomPolicy represents a CloudFront Custom Policy.
@@ -87,18 +86,7 @@ func (p CustomPolicy) String() string {
 }
 
 // signWithPrivateKey returns a binary encoding of the Custom Policy signature
-func (p CustomPolicy) signWithPrivateKey(privateKey *rsa.PrivateKey) ([]byte, error) {
-	// create a sha1 digest of our policy
-	hashFunc := crypto.SHA1
-	h := hashFunc.New()
-	io.WriteString(h, p.String())
-	digest := h.Sum(nil)
-
+func (p CustomPolicy) signWithPrivateKey(privateKey openssl.PrivateKey) ([]byte, error) {
 	// calculates the signature of digest using RSASSA-PKCS1-V1_5-SIGN from RSA PKCS#1 v1.5.
-	// NOTE: By passing in nil instead of rand.Reader here, we disable RSA blinding.
-	if signature, err := rsa.SignPKCS1v15(nil, privateKey, hashFunc, digest); err != nil {
-		return []byte{}, err
-	} else {
-		return signature, nil
-	}
+	return privateKey.SignPKCS1v15(openssl.SHA1_Method, []byte(p.String()))
 }

--- a/aws/cloudfront/signature_test.go
+++ b/aws/cloudfront/signature_test.go
@@ -90,8 +90,6 @@ func BenchmarkSignCustomPolicy(b *testing.B) {
 		b.Fatalf("%s", err)
 	}
 
-	pk.Precompute()
-
 	for i := 0; i < b.N; i++ {
 		customPolicy := NewCustomPolicy(testURL, testExpiryTime).AddStartTime(testStartTime).AddSourceIP(testSourceIP)
 		_, err := SignPolicy(pk, customPolicy, "APKA9ONS7QCOWEXAMPLE")


### PR DESCRIPTION
Significant performance boost by replacing crypto with openssl.
```
Go 1.4.1 crypto library [old]
Go 1.4.1 openssl bindings [new]

 benchmark                     old ns/op     new ns/op     delta
 BenchmarkSignCustomPolicy     7956337       2742651       -65.53%
```

Is interesting to notice that go devel show a nice improvement
over go1.4.1 crypto. Probably due math/big optimizations.
```
Go 1.4.1 crypto library [old]
Go devel +391805b Tue Feb 17 23:17:12 2015 +0000 crypto library [new]

 benchmark                     old ns/op     new ns/op     delta
 BenchmarkSignCustomPolicy     7956337       6291889       -20.92%
```