### PR TITLE
Generate RSA-SHA1 signature using openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,7 @@ This package implements:
 * [Canned Policy signing](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html).
 * [Custom Policy signing](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-custom-policy.html).
 
-*Please note:* We disable [RSA blinding](http://en.wikipedia.org/wiki/Blinding_%28cryptography%29)
-when generating signatures due to the additional CPU overhead it creates, and
-because the signing procedure never leaves this process.
+*Please note:* Due to performance reason we are using openssl c bindings.
 
 It requires a valid [CloudFront private key](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs).
 
@@ -123,9 +121,6 @@ import (
 
 func main() {
     privateKey, _ := cloudfront.NewRSAPrivateKeyFromFile("pk-KeyPairId.pem")
-
-    // if you are going to use the private key multiple time you may want to
-    // use privateKey.Precompute() which speed up private key operations.
 
     baseURL := "http://cloudfront-foobar.com/my-sweet-file.mp3"
     wildcardURL := "*/my-sweet-file.mp3"

--- a/aws/cloudfront/canned_policy.go
+++ b/aws/cloudfront/canned_policy.go
@@ -1,10 +1,7 @@
 package cloudfront
 
 import (
-	"crypto"
-	"crypto/rsa"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 )
@@ -33,18 +30,7 @@ func (p CannedPolicy) String() string {
 }
 
 // signWithPrivateKey returns a binary encoding of the Canned Policy signature
-func (p CannedPolicy) signWithPrivateKey(privateKey *rsa.PrivateKey) ([]byte, error) {
-	// create a sha1 digest of our policy
-	hashFunc := crypto.SHA1
-	h := hashFunc.New()
-	io.WriteString(h, p.String())
-	digest := h.Sum(nil)
-
+func (p CannedPolicy) signWithPrivateKey(privateKey PrivateKey) ([]byte, error) {
 	// calculates the signature of digest using RSASSA-PKCS1-V1_5-SIGN from RSA PKCS#1 v1.5.
-	// NOTE: By passing in nil instead of rand.Reader here, we disable RSA blinding.
-	if signature, err := rsa.SignPKCS1v15(nil, privateKey, hashFunc, digest); err != nil {
-		return []byte{}, err
-	} else {
-		return signature, nil
-	}
+	return privateKey.SignPKCS1v15([]byte(p.String()))
 }

--- a/aws/cloudfront/custom_policy.go
+++ b/aws/cloudfront/custom_policy.go
@@ -2,10 +2,7 @@ package cloudfront
 
 import (
 	"bytes"
-	"crypto"
-	"crypto/rsa"
 	"encoding/json"
-	"io"
 	"strings"
 	"time"
 )
@@ -87,18 +84,7 @@ func (p CustomPolicy) String() string {
 }
 
 // signWithPrivateKey returns a binary encoding of the Custom Policy signature
-func (p CustomPolicy) signWithPrivateKey(privateKey *rsa.PrivateKey) ([]byte, error) {
-	// create a sha1 digest of our policy
-	hashFunc := crypto.SHA1
-	h := hashFunc.New()
-	io.WriteString(h, p.String())
-	digest := h.Sum(nil)
-
+func (p CustomPolicy) signWithPrivateKey(privateKey PrivateKey) ([]byte, error) {
 	// calculates the signature of digest using RSASSA-PKCS1-V1_5-SIGN from RSA PKCS#1 v1.5.
-	// NOTE: By passing in nil instead of rand.Reader here, we disable RSA blinding.
-	if signature, err := rsa.SignPKCS1v15(nil, privateKey, hashFunc, digest); err != nil {
-		return []byte{}, err
-	} else {
-		return signature, nil
-	}
+	return privateKey.SignPKCS1v15([]byte(p.String()))
 }

--- a/aws/cloudfront/signature.go
+++ b/aws/cloudfront/signature.go
@@ -1,10 +1,7 @@
 package cloudfront
 
 import (
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,32 +14,19 @@ const encodeCloudFront = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01
 // PolicySigner is the interface implemented by an object that can return a
 // signed string representing its CloudFront policy.
 type PolicySigner interface {
-	signWithPrivateKey(*rsa.PrivateKey) ([]byte, error)
+	signWithPrivateKey(PrivateKey) ([]byte, error)
 	String() string
 }
 
 // NewRSAPRivateKeyFromBytes get the first block of a PEM encoded bytes
 // and return a rsa.PrivateKey
-func NewRSAPrivateKeyFromBytes(b []byte) (*rsa.PrivateKey, error) {
-	// ignore blocks other than the first one  as our file contains only one private key
-	block, _ := pem.Decode(b)
-
-	if block == nil {
-		return nil, fmt.Errorf("Cannot decode PEM data")
-	}
-
-	// get a RSA private key from its ASN.1 PKCS#1 DER encoded form.
-	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot parse PKCS1 Private Key %v: %v", err)
-	} else {
-		return key, nil
-	}
+func NewRSAPrivateKeyFromBytes(b []byte) (PrivateKey, error) {
+	return LoadPrivateKeyFromPEM(b)
 }
 
 // NewRSAPrivateKeyFromFile call NewRSAPRivateKeyFromBytes on the content
 // of filename, returning an rsa.PrivateKey
-func NewRSAPrivateKeyFromFile(filename string) (*rsa.PrivateKey, error) {
+func NewRSAPrivateKeyFromFile(filename string) (PrivateKey, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot open private key file %v: %v", filename, err)
@@ -67,7 +51,7 @@ func NewRSAPrivateKeyFromFile(filename string) (*rsa.PrivateKey, error) {
 //   http://goo.gl/pvA97e
 // Command line equivalent:
 //   cat policy | openssl sha1 -sign cloudfront-keypair.pem | openssl base64 | tr '+=/' '-_~'
-func SignPolicy(privateKey *rsa.PrivateKey, policy PolicySigner, keyPairID string) (string, error) {
+func SignPolicy(privateKey PrivateKey, policy PolicySigner, keyPairID string) (string, error) {
 	signature, err := policy.signWithPrivateKey(privateKey)
 	if err != nil {
 		return "", fmt.Errorf("Cannot sign policy: %v", err)

--- a/aws/cloudfront/ssl.go
+++ b/aws/cloudfront/ssl.go
@@ -1,0 +1,115 @@
+package cloudfront
+
+//
+// Minimum set of OpenSSL bindings to perform RSA-SHA1 signing
+// using a PEM encoded RSA signature.
+//
+
+/*
+#cgo pkg-config: libssl
+#cgo darwin CFLAGS: -Wno-deprecated-declarations
+
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
+
+int EVP_SignInit_not_a_macro(EVP_MD_CTX *ctx, const EVP_MD *type) { return EVP_SignInit(ctx, type); }
+int EVP_SignUpdate_not_a_macro(EVP_MD_CTX *ctx, const void *d, unsigned int cnt) { return EVP_SignUpdate(ctx, d, cnt); }
+*/
+import "C"
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+var sslMutex = &sync.Mutex{}
+
+type PrivateKey interface {
+	// Signs the data using PKCS1.15
+	SignPKCS1v15([]byte) ([]byte, error)
+}
+
+type pKey struct {
+	key *C.EVP_PKEY
+}
+
+// LoadPrivateKeyFromPEM loads a private key from a PEM-encoded block.
+func LoadPrivateKeyFromPEM(pem_block []byte) (PrivateKey, error) {
+	//
+	// Check and load the PEM data
+	//
+	if len(pem_block) == 0 {
+		return nil, errors.New("empty pem block")
+	}
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
+		C.int(len(pem_block)))
+	if bio == nil {
+		return nil, errors.New("failed creating bio")
+	}
+	defer C.BIO_free(bio)
+
+	rsakey := C.PEM_read_bio_RSAPrivateKey(bio, nil, nil, nil)
+	if rsakey == nil {
+		return nil, errors.New("failed reading rsa key")
+	}
+	defer C.RSA_free(rsakey)
+
+	//
+	// Create a private key
+	//
+	key := C.EVP_PKEY_new()
+	if key == nil {
+		return nil, errors.New("failed converting to evp_pkey")
+	}
+	if C.EVP_PKEY_set1_RSA(key, (*C.struct_rsa_st)(rsakey)) != 1 {
+		C.EVP_PKEY_free(key)
+		return nil, errors.New("failed converting to evp_pkey")
+	}
+
+	p := &pKey{key: key}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}
+
+func (key *pKey) SignPKCS1v15(data []byte) ([]byte, error) {
+	//
+	// Initialize the context using sha1 as method, as we
+	// need to generate RSA-SHA1 signature
+	//
+	var ctx C.EVP_MD_CTX
+	C.EVP_MD_CTX_init(&ctx)
+	defer C.EVP_MD_CTX_cleanup(&ctx)
+
+	if 1 != C.EVP_SignInit_not_a_macro(&ctx, C.EVP_sha1()) {
+		return nil, errors.New("rsasha1signature: failed to init signature")
+	}
+	if len(data) > 0 {
+		if 1 != C.EVP_SignUpdate_not_a_macro(
+			&ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) {
+			return nil, errors.New("rsasha1signature: failed to update signature")
+		}
+	}
+
+	//
+	// Sign
+	//
+	sig := make([]byte, C.EVP_PKEY_size(key.key))
+	var sigblen C.uint
+
+	// prevent data race when multiple threads are spawned
+	// by the go runtime, mostly because you are performing the signing
+	// inside a concurrent http request.
+	sslMutex.Lock()
+	defer sslMutex.Unlock()
+
+	if 1 != C.EVP_SignFinal(&ctx,
+		((*C.uchar)(unsafe.Pointer(&sig[0]))), &sigblen, key.key) {
+		return nil, errors.New("rsasha1signature: failed to finalize signature")
+	}
+	return sig[:sigblen], nil
+}


### PR DESCRIPTION
Due to performance reason (see the benchmark output below)
we are switching from go crypto library to openssl.
Since we just have to deal with RSA-SHA1 signatures, we
implemented a minimum set of bindings which in theory make compilation
straightforward and should work with any recent version of openssl.

This is a breaking change.

Go 1.4.1 crypto library [old]
Go 1.4.1 openssl bindings [new]

    benchmark                     old ns/op     new ns/op     delta
    BenchmarkSignCustomPolicy     7956337       2742651       -65.53%

Is interesting to notice that go devel show a nice improvement
over go1.4.1 crypto. Probably due math/big optimizations.
Still not enough to match openssl but promising.

Go 1.4.1 crypto library [old]
Go devel +391805b Tue Feb 17 23:17:12 2015 +0000 crypto library [new]

    benchmark                     old ns/op     new ns/op     delta
    BenchmarkSignCustomPolicy     7956337       6291889       -20.92%